### PR TITLE
adding additoonal search paths for gfortran because: OS X

### DIFF
--- a/astromodels/functions/functions.py
+++ b/astromodels/functions/functions.py
@@ -249,7 +249,8 @@ class SmoothlyBrokenPowerLaw(Function1D):
 
             desc : normalization
             initial value : 1
-
+            min : 0
+    
 
         low_index :
 
@@ -653,7 +654,8 @@ class Blackbody(Function1D):
         K :
             desc :
             initial value : 1e-4
-
+            min : 0.
+    
         kT :
             desc : temperature of the blackbody
             initial value : 30.0

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,62 @@ def setup_xspec():
     # then there is also gfortran somewhere because it is a dependence
     libraries.append('gfortran')
 
+    # OS X users who have installed libgfortran via homebrew will have gfortran installed in a non-standard
+    # directory (typically /usr/local/gfortran/lib) instead of /usr/local/lib. We need to check both
+
+    # Linux/UNIX
+
+    search_path = os.path.join(library_dirs[0], 'libgfortran.so')
+
+    valid_paths = glob.glob(search_path)
+
+
+    if len(valid_paths) == 0:
+
+        # Mac / OS X
+
+        search_path = os.path.join(library_dirs[0], 'libgfortran.dylib')
+
+        valid_paths = glob.glob(search_path)
+
+        if len(valid_paths) == 0:
+
+            # Ok now we need to check the common alternative directories
+
+            alt_gfortran_lib_dir = '/usr/local/gfortran/lib'
+
+
+            # Linux/Unix
+
+            search_path = os.path.join(alt_gfortran_lib_dir, 'libgfortran.so')
+
+            valid_paths = glob.glob(search_path)
+
+            if len(valid_paths) == 0:
+
+
+                # Mac / OS X
+
+                search_path = os.path.join(alt_gfortran_lib_dir, 'libgfortran.dylib')
+
+                valid_paths = glob.glob(search_path)
+
+                if len(valid_paths) == 0:
+
+                    print ('\nError: Could not find the libgfortran. XSPEC will cause a compile error.')
+
+                else:
+
+                    library_dirs.append(alt_gfortran_lib_dir)
+
+            else:
+
+                library_dirs.append(alt_gfortran_lib_dir)
+
+
+
+
+
     # Configure the variables to build the external module with the C/C++ wrapper
 
     ext_modules_configuration = [


### PR DESCRIPTION
This fixes a gfortran lookup for OS X. Users installing gfortran via home-brew have gfortran under /usr/local/gfortran/lib 

There were a couple of complaints about it and I was manually hacking the setup file. However, this looks for gfortran in the standard places and as a last resort looks for the home-brew version. 