### PR TITLE
fixed hashing of linked parameters

### DIFF
--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -115,8 +115,9 @@ def memoize(method):
     def memoizer(instance, x, *args, **kwargs):
 
         # Create a tuple because a tuple is hashable
+        # Explicity making values float to enable hashing. J. Michael Burgess
 
-        unique_id = tuple(x.value for x in instance.parameters.values()) + (x.shape[0], x.min(), x.max())
+        unique_id = tuple(float(x.value) for x in instance.parameters.values()) + (x.shape[0], x.min(), x.max())
 
         # Create a unique identifier for this combination of inputs
 


### PR DESCRIPTION
When using linked parameters, the return of the parameter.value member seems to always be a 0-D array. I'm not sure if there is a reason for this, but it was confusing the hashing of a tuple.

I've made an explicit cast to float when creating the unique_id. This should fix #25 