### PR TITLE
added the return of paths that clibs sees but are set in external var…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,9 @@ def find_library(library_root):
     if first_guess is not None:
 
         # Found in one of the system paths that the linker already knows
-
-        return sanitize_lib_name(first_guess), None
+        # also return the path just incase the linker see environment variables
+        # we will not catch
+        return sanitize_lib_name(first_guess), '/'.join(first_guess.split('/')[:-1])
 
     else:
 


### PR DESCRIPTION
…iables

This fixes the install on osx. What was happening is that ctypes can see the DYLD_LIBRARY_LOAD path and then it wasn't being added onto the linker. This fixes that