### PR TITLE
1D templates were failing. added np.atleast_1d to fix

### DIFF
--- a/astromodels/functions/template_model.py
+++ b/astromodels/functions/template_model.py
@@ -410,7 +410,7 @@ class TemplateModel(Function1D):
 
         # Figure out the shape of the data matrices
         data_shape = map(lambda x: x.shape[0], self._parameters_grids.values())
-
+        
         self._interpolators = []
 
         for energy in self._energies:
@@ -487,7 +487,7 @@ class TemplateModel(Function1D):
         # Gather all interpolations for these parameters' values at all defined energies
         # (these are the logarithm of the values)
 
-        log_interpolations = np.array(map(lambda i:self._interpolators[i](parameters_values),
+        log_interpolations = np.array(map(lambda i:self._interpolators[i](np.atleast_1d(parameters_values)),
                                           range(self._energies.shape[0])))
 
         # Now interpolate the interpolations to get the flux at the requested energies

--- a/astromodels/tests/test_template_model.py
+++ b/astromodels/tests/test_template_model.py
@@ -17,6 +17,35 @@ def get_comparison_function():
 
     return mo
 
+
+@pytest.mark.slow
+def test_template_factory_1D():
+
+    mo = get_comparison_function()
+
+    energies = np.logspace(1, 3, 50)
+
+    t = TemplateModelFactory('__test1D', 'A test template', energies, ['alpha'])
+
+    alpha_grid = np.linspace(-1.5, 1, 15)
+    #beta_grid = np.linspace(-3.5, -1.6, 15)
+    #xp_grid = np.logspace(1, 3, 20)
+
+    t.define_parameter_grid('alpha', alpha_grid)
+
+
+    for a in alpha_grid:
+        mo.alpha = a
+        mo.beta = -2.5
+        mo.xp = 300.
+
+
+        t.add_interpolation_data(mo(energies), alpha=a)
+
+    print("Data has been prepared")
+
+    t.save_data(overwrite=True)
+
 @pytest.mark.slow
 def test_template_factory():
 
@@ -48,6 +77,12 @@ def test_template_factory():
     print("Data has been prepared")
 
     t.save_data(overwrite=True)
+
+    tm = TemplateModel('__test1D')
+
+    tm(energies)
+
+
 
 
 # This will be run second, so the template will exist


### PR DESCRIPTION
I noticed that 1D template models were failing due to a map. I added a check to expand the dimension as needed.