### PR TITLE
A few 2D and 3D functions

### DIFF
--- a/astromodels/functions/functions_2D.py
+++ b/astromodels/functions/functions_2D.py
@@ -510,7 +510,7 @@ class Power_law_on_sphere(Function2D):
         self.index.unit = u.dimensionless_unscaled
         self.maxr.unit = x_unit
 
-    def evaluate(self, x, y, lon0, lat0, index):
+    def evaluate(self, x, y, lon0, lat0, index, maxr):
 
         lon, lat = x,y
 

--- a/astromodels/functions/functions_2D.py
+++ b/astromodels/functions/functions_2D.py
@@ -517,25 +517,18 @@ class Power_law_on_sphere(Function2D):
         angsep = angular_distance(lon0, lat0, lon, lat)
 
         if self.maxr.value <= 0.05:
-            norm = np.power(180 / np.pi, -2.-self.index.value) * np.pi
-                   * self.maxr.value**2 * 0.05**self.index.value
+            norm = np.power(180 / np.pi, -2.-self.index.value) * np.pi * self.maxr.value**2 * 0.05**self.index.value
         elif self.index.value == -2.:
-            norm = np.power(0.05 * np.pi / 180., 2.+self.index.value) * np.pi
-                   + 2. * np.pi * np.log(self.maxr.value / 0.05)
+            norm = np.power(0.05 * np.pi / 180., 2.+self.index.value) * np.pi + 2. * np.pi * np.log(self.maxr.value / 0.05)
         else:
-            norm = np.power(0.05 * np.pi / 180., 2.+self.index.value) * np.pi + 2. * np.pi
-                   * (np.power(self.maxr.value * np.pi / 180., self.index.value+2.)
-                      - np.power(0.05 * np.pi / 180., self.index.value+2.))
+            norm = np.power(0.05 * np.pi / 180., 2.+self.index.value) * np.pi + 2. * np.pi * (np.power(self.maxr.value * np.pi / 180., self.index.value+2.) - np.power(0.05 * np.pi / 180., self.index.value+2.))
             
 
-        return np.less_equal(angsep,self.maxr.value) * np.power(180 / np.pi, -1. * index) 
-               * np.power(np.add(np.multiply(angsep, np.greater(angsep, 0.05)), 
-                                 np.multiply(0.05, np.less_equal(angsep, 0.05))), index) / norm
+        return np.less_equal(angsep,self.maxr.value) * np.power(180 / np.pi, -1. * index) * np.power(np.add(np.multiply(angsep, np.greater(angsep, 0.05)), np.multiply(0.05, np.less_equal(angsep, 0.05))), index) / norm
 
     def get_boundaries(self):
 
-        return ((self.lon0.value - self.maxr.value), (self.lon0.value + self.maxr.value)),
-               ((self.lat0.value - self.maxr.value), (self.lat0.value + self.maxr.value))
+        return ((self.lon0.value - self.maxr.value), (self.lon0.value + self.maxr.value)), ((self.lat0.value - self.maxr.value), (self.lat0.value + self.maxr.value))
 
 
 # class FunctionIntegrator(Function2D):

--- a/astromodels/functions/functions_2D.py
+++ b/astromodels/functions/functions_2D.py
@@ -458,6 +458,63 @@ class SpatialTemplate_2D(Function2D):
         
         return (min_lon, max_lon), (min_lat, max_lat)
 
+class PowerLaw_on_sphere(Function2D):
+    r"""
+        description :
+
+            A power law function on a sphere (in spherical coordinates)
+
+        latex : $$ f(\vec{x}) = \left(\frac{180}{\pi}\right)^{-1.*index}  \left\{\begin{matrix} 0.05^{index} & {\rm if} & |\vec{x}-\vec{x}_0| \le 0.05\\ |\vec{x}-\vec{x}_0|^{index} & {\rm if} & |\vec{x}-\vec{x}_0| > 0.05\end{matrix}\right. $$
+
+        parameters :
+
+            lon0 :
+
+                desc : Longitude of the center of the source
+                initial value : 0.0
+                min : 0.0
+                max : 360.0
+
+            lat0 :
+
+                desc : Latitude of the center of the source
+                initial value : 0.0
+                min : -90.0
+                max : 90.0
+
+            index :
+
+                desc : power law index
+                initial value : -2.0
+                min : -5.0
+                max : -1.0
+
+        """
+
+    __metaclass__ = FunctionMeta
+
+    def _set_units(self, x_unit, y_unit, z_unit):
+
+        # lon0 and lat0 and rdiff have most probably all units of degrees. However,
+        # let's set them up here just to save for the possibility of using the
+        # formula with other units (although it is probably never going to happen)
+
+        self.lon0.unit = x_unit
+        self.lat0.unit = y_unit
+        self.index.unit = u.dimensionless_unscaled
+
+    def evaluate(self, x, y, lon0, lat0, index):
+
+        lon, lat = x,y
+
+        angsep = angular_distance(lon0, lat0, lon, lat)
+
+        return np.power(180 / np.pi, -1. * index) * np.power(np.add(np.multiply(angsep, np.greater(angsep, 0.05)), np.multiply(0.05, np.less_equal(angsep, 0.05))), index)
+
+    def get_boundaries(self):
+
+        return ((self.lon0.value - 5), (self.lon0.value + 5)), ((self.lat0.value - 5), (self.lat0.value + 5))
+
 
 # class FunctionIntegrator(Function2D):
 #     r"""

--- a/astromodels/functions/functions_2D.py
+++ b/astromodels/functions/functions_2D.py
@@ -464,7 +464,7 @@ class Power_law_on_sphere(Function2D):
 
             A power law function on a sphere (in spherical coordinates)
 
-        latex : $$ f(\vec{x}) = \left(\frac{180}{\pi}\right)^{-1.*index}  \left\{\begin{matrix} 0.05^{index} & {\rm if} & |\vec{x}-\vec{x}_0| \le 0.05\\ |\vec{x}-\vec{x}_0|^{index} & {\rm if} & |\vec{x}-\vec{x}_0| > 0.05\end{matrix}\right. $$
+        latex : $$ f(\vec{x}) = \left(\frac{180}{\pi}\right)^{-1.*index}  \left\{\begin{matrix} 0.05^{index} & {\rm if} & |\vec{x}-\vec{x}_0| \le 0.05\\ |\vec{x}-\vec{x}_0|^{index} & {\rm if} & 0.05 < |\vec{x}-\vec{x}_0| \le maxr \\ 0 & {\rm if} & |\vec{x}-\vec{x}_0|>maxr\end{matrix}\right. $$
 
         parameters :
 

--- a/astromodels/functions/functions_2D.py
+++ b/astromodels/functions/functions_2D.py
@@ -76,8 +76,7 @@ class Latitude_galactic_diffuse(Function2D):
         b = _coord.transform_to('galactic').b.value
         l = _coord.transform_to('galactic').l.value
 
-        return K * np.exp(-b ** 2 / (2 * sigma_b ** 2)) * np.logical_or(np.logical_and(l > l_min, l < l_max),np.logical_
-and(l_min > l_max, np.logical_or(l > l_min, l < l_max)))
+        return K * np.exp(-b ** 2 / (2 * sigma_b ** 2)) * np.logical_or(np.logical_and(l > l_min, l < l_max),np.logical_and(l_min > l_max, np.logical_or(l > l_min, l < l_max)))
 
     def get_boundaries(self):
 
@@ -85,8 +84,7 @@ and(l_min > l_max, np.logical_or(l > l_min, l < l_max)))
         l_min = self.l_min.value
         l_max = self.l_max.value
 
-        _coord = SkyCoord(l=[l_min, l_min, l_max, l_max], b=[max_b * -2., max_b * 2., max_b * 2., max_b * -2.], frame="g
-alactic", unit="deg")
+        _coord = SkyCoord(l=[l_min, l_min, l_max, l_max], b=[max_b * -2., max_b * 2., max_b * 2., max_b * -2.], frame="galactic", unit="deg")
 
         # no dealing with 0 360 overflow
         min_lat = min(_coord.transform_to("icrs").dec.value)

--- a/astromodels/functions/functions_3D.py
+++ b/astromodels/functions/functions_3D.py
@@ -151,26 +151,11 @@ class Continuous_injection_diffusion_ellipse(Function3D):
         rdiffs_a, thetas = np.meshgrid(rdiff_a, theta)
         rdiffs_b, angseps = np.meshgrid(rdiff_b, angsep)
 
-        #print(rdiffs_a.shape)
-        #print(rdiffs_b.shape)
-        #print(thetas.shape)
-        #print(angseps.shape)
-
         rdiffs = np.sqrt(rdiffs_a ** 2 * np.cos(thetas) ** 2 + rdiffs_b ** 2 * np.sin(thetas) ** 2)
 
 
-        #print(lon)
-        #print(lat)
-        #print(thetas[:,0])
-
-        #print(angseps[:,0])
-
-        #print(rdiffs[:,0])
-
-        #results = np.power(180.0 / pi, 2) * 1.2154 / (pi * np.sqrt(pi) * rdiffs * (angseps + 0.06 * rdiffs)) *  np.exp(-np.power(angseps, 2) / rdiffs ** 2)
         results = np.power(180.0 / pi, 2) * 1.22 / (pi * np.sqrt(pi) * rdiffs_a * np.sqrt(elongation) * (angseps + 0.06 * rdiffs)) *  np.exp(-np.power(angseps, 2) / rdiffs ** 2)
 
-        #print(results[:,0])
         return results
 
 

--- a/astromodels/functions/functions_3D.py
+++ b/astromodels/functions/functions_3D.py
@@ -7,7 +7,8 @@ import numpy as np
 from astromodels.utils.angular_distance import angular_distance
 
 
-class Continuous_injection_diffusion(Function3D):
+
+class Continuous_injection_diffusion_ellipse(Function3D):
     r"""
         description :
 
@@ -46,12 +47,217 @@ class Continuous_injection_diffusion(Function3D):
                 max : 0.6
                 fix : yes
 
-            uratio :
+            b :
 
-                desc : ratio between u_cmb and u_B
+                desc : b field strength in uG
+                initial value : 3
+                min : 1
+                max : 10.
+                fix : yes
+
+            piv :
+
+                desc : Pivot for the diffusion radius
+                initial value : 2e10
+                min : 0
+                fix : yes
+
+            piv2 :
+
+                desc : Pivot for converting gamma energy to electron energy (always be 1 TeV)
+                initial value : 1e9
+                min : 0
+                fix : yes
+
+            incl :
+
+                desc : inclination of semimajoraxis to a line of constant latitude
+                initial value : 0.0
+                min : -90.0
+                max : 90.0
+                fix : yes
+
+            elongation :
+
+                desc : elongation of the ellipse (b/a)
+                initial value : 1.
+                min : 0.1
+                max : 10.
+
+        """
+
+    __metaclass__ = FunctionMeta
+
+    def _set_units(self, x_unit, y_unit, z_unit, w_unit):
+
+        # lon0 and lat0 and rdiff have most probably all units of degrees. However,
+        # let's set them up here just to save for the possibility of using the
+        # formula with other units (although it is probably never going to happen)
+
+        self.lon0.unit = x_unit
+        self.lat0.unit = y_unit
+        self.rdiff0.unit = x_unit
+
+        # Delta is of course unitless
+
+        self.delta.unit = u.dimensionless_unscaled
+        self.b.unit = u.dimensionless_unscaled
+        self.incl.unit = x_unit
+        self.elongation.unit = u.dimensionless_unscaled
+
+        # Piv has the same unit as energy (which is z)
+
+        self.piv.unit = z_unit
+        self.piv2.unit = z_unit
+
+    def evaluate(self, x, y, z, lon0, lat0, rdiff0, delta, b, piv, piv2, incl, elongation):
+
+        lon, lat = x, y
+        energy = z
+
+        # energy in kev -> TeV.
+        # NOTE: the use of piv2 is necessary to preserve dimensional correctness: the logarithm can only be taken
+        # of a dimensionless quantity, so there must be a pivot there.
+
+        e_energy_piv2 = 17. * np.power(energy / piv2, 0.54 + 0.046 * np.log10(energy / piv2))
+        e_piv_piv2 = 17. * np.power(piv / piv2, 0.54 + 0.046 * np.log10(piv / piv2))
+
+        try:
+
+            rdiff_a = rdiff0 * np.power(e_energy_piv2 / e_piv_piv2, (delta - 1.) / 2.) * \
+                    np.sqrt(b * b / 8. / np.pi * 0.624 + 0.26 * np.power(1. + 0.0107 * e_piv_piv2, -1.5)) / \
+                    np.sqrt(b * b / 8. / np.pi * 0.624 + 0.26 * np.power(1. + 0.0107 * e_energy_piv2, -1.5))
+
+        except ValueError:
+
+            # This happens when using units, because astropy.units fails with the message:
+            # "ValueError: Quantities and Units may only be raised to a scalar power"
+
+            # Work around the problem with this loop, which is slow but using units is only for testing purposes or
+            # single calls, so it shouldn't matter too much
+            rdiff_a = np.array( map(lambda x: (rdiff0 * np.power(e_energy_pivi2 / e_piv_piv2, x)).value,
+                                  (delta - 1.) / 2. * np.sqrt(b * b / 8. / np.pi * 0.624 + 0.26 * np.power(1. + 0.0107 * e_piv_piv2, -1.5)) /
+                                  np.sqrt(b * b / 8. / np.pi * 0.624 + 0.26 * np.power(1. + 0.0107 * e_energy_piv2, -1.5)))) * rdiff0.unit
+
+        rdiff_b = rdiff_a * elongation
+
+        pi = np.pi
+
+        angsep = angular_distance(lon, lat, lon0, lat0)
+        ang = np.arctan2(lat - lat0, (lon - lon0) * np.cos(lat0 * np.pi / 180.))
+
+        theta = np.arctan2(np.sin(ang-incl*np.pi/180.)/elongation, np.cos(ang-incl*np.pi/180.))
+
+        rdiffs_a, thetas = np.meshgrid(rdiff_a, theta)
+        rdiffs_b, angseps = np.meshgrid(rdiff_b, angsep)
+
+        #print(rdiffs_a.shape)
+        #print(rdiffs_b.shape)
+        #print(thetas.shape)
+        #print(angseps.shape)
+
+        rdiffs = np.sqrt(rdiffs_a ** 2 * np.cos(thetas) ** 2 + rdiffs_b ** 2 * np.sin(thetas) ** 2)
+
+
+        #print(lon)
+        #print(lat)
+        #print(thetas[:,0])
+
+        #print(angseps[:,0])
+
+        #print(rdiffs[:,0])
+
+        #results = np.power(180.0 / pi, 2) * 1.2154 / (pi * np.sqrt(pi) * rdiffs * (angseps + 0.06 * rdiffs)) *  np.exp(-np.power(angseps, 2) / rdiffs ** 2)
+        results = np.power(180.0 / pi, 2) * 1.22 / (pi * np.sqrt(pi) * rdiffs_a * np.sqrt(elongation) * (angseps + 0.06 * rdiffs)) *  np.exp(-np.power(angseps, 2) / rdiffs ** 2)
+
+        #print(results[:,0])
+        return results
+
+
+    def get_boundaries(self):
+
+        # Truncate the function at the max of rdiff allowed
+
+        maximum_rdiff = self.rdiff0.max_value
+
+        min_latitude = max(-90., self.lat0.value - maximum_rdiff)
+        max_latitude = min(90., self.lat0.value + maximum_rdiff)
+
+        max_abs_lat = max(np.absolute(min_latitude), np.absolute(max_latitude))
+
+        if max_abs_lat > 89. or maximum_rdiff / np.cos(max_abs_lat * np.pi / 180.) >= 180.:
+
+            min_longitude = 0.
+            max_longitude = 360.
+
+        else:
+
+            min_longitude = self.lon0.value - maximum_rdiff / np.cos(max_abs_lat * np.pi / 180.)
+            max_longitude = self.lon0.value + maximum_rdiff / np.cos(max_abs_lat * np.pi / 180.)
+
+            if min_longitude < 0.:
+
+                min_longitude += 360.
+
+            elif max_longitude > 360.:
+
+                max_longitude -= 360.
+
+        return (min_longitude, max_longitude), (min_latitude, max_latitude)
+
+class Continuous_injection_diffusion(Function3D):
+    r"""
+        description :
+
+            Positron and electrons diffusing away from the accelerator
+
+        latex : $\left(\frac{180^\circ}{\pi}\right)^2 \frac{1.2154}{\sqrt{\pi^3} r_{\rm diff} ({\rm angsep} ({\rm x, y, lon_0, lat_0})+0.06 r_{\rm diff} )} \, {\rm exp}\left(-\frac{{\rm angsep}^2 ({\rm x, y, lon_0, lat_0})}{r_{\rm diff} ^2} \right)$
+
+        parameters :
+
+            lon0 :
+
+                desc : Longitude of the center of the source
+                initial value : 0.0
+                min : 0.0
+                max : 360.0
+
+            lat0 :
+
+                desc : Latitude of the center of the source
+                initial value : 0.0
+                min : -90.0
+                max : 90.0
+
+            rdiff0 :
+
+                desc : Projected diffusion radius limited by the cooling time. The maximum allowed value is used to define the truncation radius.
+                initial value : 1.0
+                min : 0
+                max : 20
+
+            rinj :
+
+                desc : Ratio of diffusion radius limited by the injection time over rdiff0. The maximum allowed value is used to define the truncation radius.
+                initial value : 100.0
+                min : 0
+                max : 200
+                fix : yes
+
+            delta :
+
+                desc : index for the diffusion coefficient
                 initial value : 0.5
-                min : 0.01
-                max : 100.
+                min : 0.3
+                max : 0.6
+                fix : yes
+
+            b :
+
+                desc : b field strength in uG
+                initial value : 3
+                min : 1
+                max : 10.
                 fix : yes
 
             piv :
@@ -80,18 +286,19 @@ class Continuous_injection_diffusion(Function3D):
         self.lon0.unit = x_unit
         self.lat0.unit = y_unit
         self.rdiff0.unit = x_unit
+        self.rinj.unit = u.dimensionless_unscaled
 
         # Delta is of course unitless
 
         self.delta.unit = u.dimensionless_unscaled
-        self.uratio.unit = u.dimensionless_unscaled
+        self.b.unit = u.dimensionless_unscaled
 
         # Piv has the same unit as energy (which is z)
 
         self.piv.unit = z_unit
         self.piv2.unit = z_unit
 
-    def evaluate(self, x, y, z, lon0, lat0, rdiff0, delta, uratio, piv, piv2):
+    def evaluate(self, x, y, z, lon0, lat0, rdiff0, rinj, delta, b, piv, piv2):
 
         lon, lat = x, y
         energy = z
@@ -105,9 +312,11 @@ class Continuous_injection_diffusion(Function3D):
 
         try:
 
-            rdiff = rdiff0 * np.power(e_energy_piv2 / e_piv_piv2, (delta - 1.) / 2.) * \
-                    np.sqrt(1. + uratio * np.power(1. + 0.0107 * e_piv_piv2, -1.5)) / \
-                    np.sqrt(1. + uratio * np.power(1. + 0.0107 * e_energy_piv2, -1.5))
+            rdiff_c = rdiff0 * np.power(e_energy_piv2 / e_piv_piv2, (delta - 1.) / 2.) * \
+                    np.sqrt(b * b / 8. / np.pi * 0.624 + 0.26 * np.power(1. + 0.0107 * e_piv_piv2, -1.5)) / \
+                    np.sqrt(b * b / 8. / np.pi * 0.624 + 0.26 * np.power(1. + 0.0107 * e_energy_piv2, -1.5))
+
+            rdiff_i = rdiff0 * rinj * np.power(e_energy_piv2 / e_piv_piv2, delta / 2.)
 
         except ValueError:
 
@@ -116,9 +325,14 @@ class Continuous_injection_diffusion(Function3D):
 
             # Work around the problem with this loop, which is slow but using units is only for testing purposes or
             # single calls, so it shouldn't matter too much
-            rdiff = np.array( map(lambda x: (rdiff0 * np.power(e_energy_pivi2 / e_piv_piv2, x)).value,
-                                  (delta - 1.) / 2. * np.sqrt(1. + uratio * np.power(1. + 0.0107 * e_piv_piv2, -1.5)) /
-                                  np.sqrt(1. + uratio * np.power(1. + 0.0107 * e_energy_piv2, -1.5)))) * rdiff0.unit
+            rdiff_c = np.array( map(lambda x: (rdiff0 * np.power(e_energy_pivi2 / e_piv_piv2, x)
+                                   * np.sqrt(b * b / 8. / np.pi * 0.624 + 0.26 * np.power(1. + 0.0107 * e_piv_piv2, -1.5)) /
+                                  np.sqrt(b * b / 8. / np.pi * 0.624 + 0.26 * np.power(1. + 0.0107 * e_energy_piv2, -1.5)), (delta - 1.) / 2.).value)) * rdiff0.unit
+
+            rdiff_i = np.array( map(lambda x: (rdiff0 * rinj * np.power(e_energy_piv2 / e_piv_piv2, x), delta / 2.).value)) * rdiff0.unit
+            raise ValueError("")
+
+        rdiff = np.minimum(rdiff_c, rdiff_i)
 
         angsep = angular_distance(lon, lat, lon0, lat0)
 
@@ -160,3 +374,4 @@ class Continuous_injection_diffusion(Function3D):
                 max_longitude -= 360.
 
         return (min_longitude, max_longitude), (min_latitude, max_latitude)
+


### PR DESCRIPTION
This pull request includes the following implementations:

1. add get_boundaries() for Lataitude_Galactic_Diffuse (temporary solution, will edit LIFF so we can completely get rid of get_boundaries())
2. add powerLaw_on_sphere function to define a 1/r^n morphology
3. in Continuous_injection_diffusion, change uratio to b (magnetic field) so it is more clear what it is, also add parameter rinj to define energy-dependent diffusion radius limited by the injection time (age).
4. add Continuous_injection_diffusion_ellipse, which is an asymmetric diffusion model.