### PR TITLE
fix bug on norm in power_law_on_sphere

### DIFF
--- a/astromodels/functions/functions_2D.py
+++ b/astromodels/functions/functions_2D.py
@@ -688,14 +688,13 @@ class Power_law_on_sphere(Function2D):
         angsep = angular_distance(lon0, lat0, lon, lat)
 
         if self.maxr.value <= 0.05:
-            norm = np.power(180 / np.pi, -2.-self.index.value) * np.pi * self.maxr.value**2 * 0.05**self.index.value
+            norm = np.power(np.pi / 180., 2.+index) * np.pi * maxr**2 * 0.05**index
         elif self.index.value == -2.:
-            norm = np.power(0.05 * np.pi / 180., 2.+self.index.value) * np.pi + 2. * np.pi * np.log(self.maxr.value / 0.05)
+            norm = np.power(0.05 * np.pi / 180., 2.+index) * np.pi + 2. * np.pi * np.log(maxr / 0.05)
         else:
-            norm = np.power(0.05 * np.pi / 180., 2.+self.index.value) * np.pi + 2. * np.pi * (np.power(self.maxr.value * np.pi / 180., self.index.value+2.) - np.power(0.05 * np.pi / 180., self.index.value+2.))
-            
+            norm = np.power(0.05 * np.pi / 180., 2.+index) * np.pi + 2. * np.pi / (2.+index) * (np.power(maxr * np.pi / 180., index+2.) - np.power(0.05 * np.pi / 180., index+2.))
 
-        return np.less_equal(angsep,self.maxr.value) * np.power(180 / np.pi, -1. * index) * np.power(np.add(np.multiply(angsep, np.greater(angsep, 0.05)), np.multiply(0.05, np.less_equal(angsep, 0.05))), index) / norm
+        return np.less_equal(angsep,maxr) * np.power(np.pi / 180., index) * np.power(np.add(np.multiply(angsep, np.greater(angsep, 0.05)), np.multiply(0.05, np.less_equal(angsep, 0.05))), index) / norm
 
     def get_boundaries(self):
 


### PR DESCRIPTION
A bug found by Henrike on the normalization of the function2D power_law_on_shpere(). It affects the spectral normalization but not spectral index, spatial index or best fit TS.