### PR TITLE
Fix Cloning 2Dtemplate model, fix units in some functions

### DIFF
--- a/astromodels/core/model_parser.py
+++ b/astromodels/core/model_parser.py
@@ -756,7 +756,10 @@ class ShapeParser(object):
                 link_function_instance = self._parse_shape_definition(component_name, link_function_name,
                                                                       this_definition['law'][link_function_name])
 
-                path = ".".join([self._source_name, 'spectrum', component_name, function_name, parameter_name])
+                if is_spatial:
+                    path = ".".join([self._source_name, function_name, parameter_name])
+                else:
+                    path = ".".join([self._source_name, 'spectrum', component_name, function_name, parameter_name])
 
                 self._links.append({'parameter_path': path,
                                     'law': link_function_instance,

--- a/astromodels/core/model_parser.py
+++ b/astromodels/core/model_parser.py
@@ -183,7 +183,8 @@ class ModelParser(object):
 
             for property, value in extra_setup['extra_setup'].iteritems():
 
-                new_model[path].__setattr__(property, new_model[value])
+                #new_model[path].__setattr__(property, new_model[value])
+                new_model[path].__setattr__(property, value)
 
         return new_model
 
@@ -563,7 +564,7 @@ class SourceParser(object):
 
         shape_parser = ShapeParser(self._source_name)
 
-        shape = shape_parser.parse(component_name, function_name, parameters_definition)
+        shape = shape_parser.parse(component_name, function_name, parameters_definition, is_spatial=False)
 
         # Get the links and extra setups, if any
 
@@ -596,7 +597,12 @@ class SourceParser(object):
 
         spatial_shape_parser = ShapeParser(self._source_name)
 
-        spatial_shape = spatial_shape_parser.parse("n.a.", name_of_spatial_shape, ext_source_definition.values()[0])
+        spatial_shape = spatial_shape_parser.parse("n.a.", name_of_spatial_shape, ext_source_definition.values()[0], is_spatial=True)
+
+        # Get the links and extra setups, if any
+
+        self._links.extend(spatial_shape_parser.links)
+        self._extra_setups.extend(spatial_shape_parser.extra_setups)
 
         # Parse the spectral information
 
@@ -640,9 +646,9 @@ class ShapeParser(object):
 
         return self._extra_setups
 
-    def parse(self, component_name, function_name, parameters_definition):
+    def parse(self, component_name, function_name, parameters_definition, is_spatial = False):
 
-        return self._parse_shape_definition(component_name, function_name, parameters_definition)
+        return self._parse_shape_definition(component_name, function_name, parameters_definition, is_spatial)
 
     @staticmethod
     def _fix(value):
@@ -651,7 +657,7 @@ class ShapeParser(object):
         # such as in units
         return value.replace("\n", " ")
 
-    def _parse_shape_definition(self, component_name, function_name, parameters_definition):
+    def _parse_shape_definition(self, component_name, function_name, parameters_definition, is_spatial=False):
 
         # Get the function
 
@@ -780,8 +786,12 @@ class ShapeParser(object):
 
         # Now handle extra_setup if any
         if 'extra_setup' in parameters_definition:
-            path = ".".join([self._source_name, 'spectrum', component_name, function_name])
-
+        
+            if is_spatial:
+                path = ".".join([self._source_name, function_name])
+            else:
+                path = ".".join([self._source_name, 'spectrum', component_name, function_name])
+                
             self._extra_setups.append({'function_path': path,
                                        'extra_setup': parameters_definition['extra_setup']})
 

--- a/astromodels/core/model_parser.py
+++ b/astromodels/core/model_parser.py
@@ -183,8 +183,12 @@ class ModelParser(object):
 
             for property, value in extra_setup['extra_setup'].iteritems():
 
-                #new_model[path].__setattr__(property, new_model[value])
-                new_model[path].__setattr__(property, value)
+                #First, check to see if the we have a valid path in the new model.
+                #If we aren't given a path, interpret it as being given a value.
+                if value in new_model:
+                  new_model[path].__setattr__(property, new_model[value])
+                else:
+                  new_model[path].__setattr__(property, value)
 
         return new_model
 

--- a/astromodels/tests/test_point_source.py
+++ b/astromodels/tests/test_point_source.py
@@ -5,6 +5,8 @@ import pytest
 from astromodels.core.spectral_component import SpectralComponent
 from astromodels.functions.functions import Powerlaw, Exponential_cutoff, Log_parabola, Blackbody, Band
 from astromodels.sources.point_source import PointSource
+from astromodels.core.model import Model
+from astromodels.core.model_parser import clone_model, load_model
 
 try:
 
@@ -155,7 +157,7 @@ def test_call_with_units():
     def test_one(class_type):
 
         instance = class_type()
-
+        
         if not instance.is_prior:
 
             # if we have fixed x_units then we will use those
@@ -174,19 +176,37 @@ def test_call_with_units():
             # Use the function as a spectrum
             ps = PointSource("test", 0, 0, instance)
 
+            if instance.name == "Synchrotron":
+                instance.set_particle_distribution(Powerlaw())
+
+
+            result = ps(1.0)
+
+            assert isinstance(result, float)
 
             result = ps(1.0 * x_unit_to_use)
-
 
             assert isinstance(result, u.Quantity)
 
             result = ps(np.array([1, 2, 3]) * x_unit_to_use)
 
             assert isinstance(result, u.Quantity)
+            
+            model = Model( ps )
+            
+            new_model = clone_model( model )
+            
+            new_result =  new_model["test"](np.array([1, 2, 3]) * x_unit_to_use)
+            
+            assert np.all(new_result==result)
 
-            result = ps(1.0)
+            model.save("__test.yml", overwrite=True)
+            
+            new_model = load_model("__test.yml")
 
-            assert isinstance(result, float)
+            new_result =  new_model["test"](np.array([1, 2, 3]) * x_unit_to_use)
+            
+            assert np.all(new_result==result)
 
         else:
 
@@ -212,6 +232,12 @@ def test_call_with_units():
             # The TemplateModel function has its own test
 
             continue
+
+#        if key.find("Synchrotron")==0:
+
+            # Naima Synchtron function should have its own test
+
+#            continue
 
         if this_function._n_dim == 1:
 

--- a/astromodels/tests/test_point_source.py
+++ b/astromodels/tests/test_point_source.py
@@ -5,6 +5,7 @@ import pytest
 from astromodels.core.spectral_component import SpectralComponent
 from astromodels.functions.functions import Powerlaw, Exponential_cutoff, Log_parabola, Blackbody, Band
 from astromodels.sources.point_source import PointSource
+from astromodels.sources.particle_source import ParticleSource
 from astromodels.core.model import Model
 from astromodels.core.model_parser import clone_model, load_model
 
@@ -176,8 +177,9 @@ def test_call_with_units():
             # Use the function as a spectrum
             ps = PointSource("test", 0, 0, instance)
 
-            if instance.name == "Synchrotron":
-                instance.set_particle_distribution(Powerlaw())
+            if instance.name in [ "Synchrotron", "_ComplexTestFunction" ]:
+                particleSource = ParticleSource("particles", Powerlaw())
+                instance.set_particle_distribution(particleSource.spectrum.main.shape)
 
 
             result = ps(1.0)
@@ -192,7 +194,10 @@ def test_call_with_units():
 
             assert isinstance(result, u.Quantity)
             
-            model = Model( ps )
+            if instance.name in [ "Synchrotron", "_ComplexTestFunction" ]:
+              model = Model( particleSource, ps)
+            else:
+              model = Model( ps )
             
             new_model = clone_model( model )
             


### PR DESCRIPTION
Fixed the issue where map information was lost when cloning a 2D template function instance. As suggested by @giacomov , the path to the fits file is saved rather than the map itself. So, the user needs to make sure that the fits file is still available when the model is cloned or loaded from a yml file.

Also added some more tests for functions (made sure they return the same value after being cloned) and made all functions calls work with and without units so all current tests pass.